### PR TITLE
[ASN-65] fix: ffmpeg 설치 명령어 포함하도록 dockerfile 수정

### DIFF
--- a/deployments/docker/media-worker.Dockerfile
+++ b/deployments/docker/media-worker.Dockerfile
@@ -1,4 +1,10 @@
 FROM eclipse-temurin:21-jre
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends ffmpeg \
+ && rm -rf /var/lib/apt/lists/* \
+ && ffmpeg -version
+
 WORKDIR /app
 COPY apps/media-worker/build/libs/*.jar app.jar
 ENTRYPOINT ["java","-jar","/app/app.jar"]


### PR DESCRIPTION
## 📝작업 내용
<!-- 작업한 내용들 명시 -->

- media-worker의 docker file 수정
    - ecs 태스크에 항상 ffmpeg이 설치되어 있도록 합니다.
<br/>

## 👀변경 사항
<!-- 팀원들이 알아야할  코드, 설정, 구조의 변경을 명시 -->


<br/>

## 🎫 Jira Ticket
- Jira Ticket: ASN-65

<br/>

## #️⃣관련 이슈

- closes #110 