### PR TITLE
fix: media-worker의 하드웨어 스펙 2vCPU, 4GB로 설정

### DIFF
--- a/infra/ecs/taskdef-media-worker.json.tpl
+++ b/infra/ecs/taskdef-media-worker.json.tpl
@@ -4,8 +4,8 @@
   "executionRoleArn": "${AWS_EXE_ROLE_ARN}",
   "networkMode": "awsvpc",
   "requiresCompatibilities": ["FARGATE"],
-  "cpu": "1024",
-  "memory": "2048",
+  "cpu": "2048",
+  "memory": "4096",
   "containerDefinitions": [
     {
       "name": "log_router",


### PR DESCRIPTION
## 📝작업 내용
<!-- 작업한 내용들 명시 -->
- media-worker의 하드웨어 스펙 2vCPU, 4GB로 설정
<br/>

## 🎫 Jira Ticket
- Jira Ticket: ASN-

<br/>

## #️⃣관련 이슈

- closes # 