### PR TITLE
fix: 2 vCPU 4GB 메모리로 픽스

### DIFF
--- a/infra/ecs/taskdef-media-worker.json.tpl
+++ b/infra/ecs/taskdef-media-worker.json.tpl
@@ -4,8 +4,8 @@
   "executionRoleArn": "${AWS_EXE_ROLE_ARN}",
   "networkMode": "awsvpc",
   "requiresCompatibilities": ["FARGATE"],
-  "cpu": "4096",
-  "memory": "8192",
+  "cpu": "2048",
+  "memory": "4096",
   "containerDefinitions": [
     {
       "name": "log_router",


### PR DESCRIPTION
## 📝작업 내용
<!-- 작업한 내용들 명시 -->
- 실험 결과 media-worker의 하드웨어 스펙은 2 vCPU 4GB 메모리로 픽스
<br/>

## 🎫 Jira Ticket
- Jira Ticket: ASN-

<br/>

## #️⃣관련 이슈

- closes # 